### PR TITLE
[박지훈]refactor: BackupIo 코드분리,Querydsl 적용

### DIFF
--- a/src/main/java/com/sprint/hrbank_sb6_1/controller/BackupController.java
+++ b/src/main/java/com/sprint/hrbank_sb6_1/controller/BackupController.java
@@ -3,7 +3,7 @@ package com.sprint.hrbank_sb6_1.controller;
 import com.sprint.hrbank_sb6_1.domain.BackupStatus;
 import com.sprint.hrbank_sb6_1.dto.BackupDto;
 import com.sprint.hrbank_sb6_1.dto.CursorPageResponseBackupDto;
-import com.sprint.hrbank_sb6_1.dto.SearchBackupRequest;
+import com.sprint.hrbank_sb6_1.dto.request.SearchBackupRequest;
 import com.sprint.hrbank_sb6_1.service.BackupService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/sprint/hrbank_sb6_1/dto/request/SearchBackupRequest.java
+++ b/src/main/java/com/sprint/hrbank_sb6_1/dto/request/SearchBackupRequest.java
@@ -1,4 +1,4 @@
-package com.sprint.hrbank_sb6_1.dto;
+package com.sprint.hrbank_sb6_1.dto.request;
 
 import com.sprint.hrbank_sb6_1.domain.BackupStatus;
 import lombok.Data;

--- a/src/main/java/com/sprint/hrbank_sb6_1/event/BackupEvent.java
+++ b/src/main/java/com/sprint/hrbank_sb6_1/event/BackupEvent.java
@@ -1,10 +1,6 @@
 package com.sprint.hrbank_sb6_1.event;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class BackupEvent {
-    Long id;
+public record BackupEvent(
+        Long id
+) {
 }

--- a/src/main/java/com/sprint/hrbank_sb6_1/event/BackupIoEvent.java
+++ b/src/main/java/com/sprint/hrbank_sb6_1/event/BackupIoEvent.java
@@ -1,0 +1,12 @@
+package com.sprint.hrbank_sb6_1.event;
+
+import com.sprint.hrbank_sb6_1.domain.Backup;
+
+public record BackupIoEvent(
+        Backup backup,
+        String fileName,
+        String type,
+        Integer size,
+        boolean err
+) {
+}

--- a/src/main/java/com/sprint/hrbank_sb6_1/repository/BackupRepositoryCustom.java
+++ b/src/main/java/com/sprint/hrbank_sb6_1/repository/BackupRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.sprint.hrbank_sb6_1.repository;
 import com.sprint.hrbank_sb6_1.domain.Backup;
-import com.sprint.hrbank_sb6_1.dto.SearchBackupRequest;
+import com.sprint.hrbank_sb6_1.dto.request.SearchBackupRequest;
 
 import org.springframework.data.domain.Slice;
 

--- a/src/main/java/com/sprint/hrbank_sb6_1/service/BackupService.java
+++ b/src/main/java/com/sprint/hrbank_sb6_1/service/BackupService.java
@@ -3,7 +3,7 @@ package com.sprint.hrbank_sb6_1.service;
 import com.sprint.hrbank_sb6_1.domain.BackupStatus;
 import com.sprint.hrbank_sb6_1.dto.BackupDto;
 import com.sprint.hrbank_sb6_1.dto.CursorPageResponseBackupDto;
-import com.sprint.hrbank_sb6_1.dto.SearchBackupRequest;
+import com.sprint.hrbank_sb6_1.dto.request.SearchBackupRequest;
 
 public interface BackupService {
     BackupDto CreateBackup(String ip);

--- a/src/main/java/com/sprint/hrbank_sb6_1/service/basic/BasicBackupService.java
+++ b/src/main/java/com/sprint/hrbank_sb6_1/service/basic/BasicBackupService.java
@@ -6,7 +6,7 @@ import com.sprint.hrbank_sb6_1.domain.File;
 import com.sprint.hrbank_sb6_1.dto.BackupDto;
 import com.sprint.hrbank_sb6_1.dto.CursorPageBackupDto;
 import com.sprint.hrbank_sb6_1.dto.CursorPageResponseBackupDto;
-import com.sprint.hrbank_sb6_1.dto.SearchBackupRequest;
+import com.sprint.hrbank_sb6_1.dto.request.SearchBackupRequest;
 import com.sprint.hrbank_sb6_1.event.BackupEvent;
 import com.sprint.hrbank_sb6_1.event.BackupIoEvent;
 import com.sprint.hrbank_sb6_1.mapper.BackupMapper;
@@ -22,7 +22,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.file.Files;
 import java.time.LocalDateTime;
 
 
@@ -97,14 +96,17 @@ public class BasicBackupService implements BackupService {
     @Transactional
     protected void setBackupStatus(BackupIoEvent backupIoEvent) {
         Backup backup= backupIoEvent.backup();
+        //BackupIo 받아온 파일 정보로 파일 객체 생성
         File file = new File(null , backupIoEvent.fileName() , backupIoEvent.type() , backupIoEvent.size());
 
+        //err여부로 백업 상태 변경 과 파일 추가
         if(backupIoEvent.err()){
             backup.markFailed(file);
         }else {
            backup.markCompleted(file);
         }
 
+        //백업, 파일정보 저장
         backupRepository.save(backup);
         fileRepository.save(file);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,4 +43,4 @@ spring:
 
       backup:
         schedule:
-          rate: 3600000
+          rate: 36000000 #자동 백업 시간 현재: 10분


### PR DESCRIPTION
# 요약
- BackupIo 코드분리,Querydsl 적용

# 작업 내용
- JPQL 문자열 조립 에서-> Querydsl 로변경
- BasicBackupIoService 백업 정보, 백업 파일 정보, 로그 파일 정보, 생성 및 저장 역할 분리

# 연관 이슈
close #64 